### PR TITLE
Fix flexible search for Arabic terms

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -126,11 +126,9 @@ export default function Home() {
               isGradingValid
             ) {
               const isContentMatch = flexibleSearch
-                ? searchTerm
-                  .trim()
-                  .toLowerCase()
-                  .split(/\s+/)
-                  .every(word => normalizedContent.includes(word))
+                ? normalizedSearchTerm
+                    .split(/\s+/)
+                    .every((word) => normalizedContent.includes(word))
                 : normalizedContent.includes(normalizedSearchTerm);
 
               if (isContentMatch) {


### PR DESCRIPTION
## Summary
- fix flexible search by normalizing the search term before splitting words

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68815e57bee0832eab5ee09f04af3435